### PR TITLE
Update to PF6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@patternfly/react-core": "^5.3.4",
-        "@patternfly/react-table": "^5.3.4",
-        "@redhat-cloud-services/frontend-components": "^4.2.14",
-        "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
+        "@redhat-cloud-services/frontend-components": "^6.0.2",
+        "@redhat-cloud-services/frontend-components-notifications": "^6.0.0",
+        "@redhat-cloud-services/frontend-components-utilities": "^6.0.2",
         "classnames": "^2.3.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1947,6 +1947,7 @@
       "version": "0.7.3",
       "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz",
       "integrity": "sha512-uxJqm/sqwXw3YPA5GXX365OBcJGFtxUVkB6WyezqFHlNe9jqUWH5ur2O2M8dGBz61kn1g3ZBlzUunFQXQIClhA==",
+      "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "0.7.1"
       }
@@ -1954,7 +1955,8 @@
     "node_modules/@emotion/memoize": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.1.tgz",
-      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg=="
+      "integrity": "sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==",
+      "license": "MIT"
     },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.0",
@@ -2980,6 +2982,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/@openshift/dynamic-plugin-sdk/-/dynamic-plugin-sdk-5.0.1.tgz",
       "integrity": "sha512-+azUBN6FgcDmlcWMzG0bthcRUJC1u12wf9xa2aJGFbC/uTiOXwjrkcQ7LW/PyK5Em7wDhwaUdapaeOgh8I6Kjg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "lodash": "^4.17.21",
         "semver": "^7.3.7",
@@ -3022,9 +3025,10 @@
       }
     },
     "node_modules/@openshift/dynamic-plugin-sdk/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3343,14 +3347,15 @@
       }
     },
     "node_modules/@patternfly/react-component-groups": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.2.0.tgz",
-      "integrity": "sha512-kb57OOVJ9L5fbY/kiil8awPWuJVops8Rz1ZNFtkEb72mF3lhmRadYNheLBeaD8T9GE1dOaVJRMMf133ZSKN87g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-6.2.1.tgz",
+      "integrity": "sha512-bPiPoVOR+mS3xdMpAv/xkbT9+PVvNhfE22JdUG2pfmWXXTP7BsmFgRo4mouSDqqDTdXz+ZDYKRkxGR5FpKMJyQ==",
+      "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "^5.1.1",
-        "@patternfly/react-icons": "^5.1.1",
-        "@patternfly/react-table": "^5.1.1",
-        "clsx": "^2.0.0",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-icons": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
+        "clsx": "^2.1.1",
         "react-jss": "^10.10.0"
       },
       "peerDependencies": {
@@ -3359,16 +3364,17 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.3.4.tgz",
-      "integrity": "sha512-zr2yeilIoFp8MFOo0vNgI8XuM+P2466zHvy4smyRNRH2/but2WObqx7Wu4ftd/eBMYdNqmTeuXe6JeqqRqnPMQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.2.2.tgz",
+      "integrity": "sha512-JUrZ57JQ4bkmed1kxaciXb0ZpIVYyCHc2HjtzoKQ5UNRlx204zR2isATSHjdw2GFcWvwpkC5/fU2BR+oT3opbg==",
+      "license": "MIT",
       "dependencies": {
-        "@patternfly/react-icons": "^5.3.2",
-        "@patternfly/react-styles": "^5.3.1",
-        "@patternfly/react-tokens": "^5.3.1",
-        "focus-trap": "7.5.2",
-        "react-dropzone": "^14.2.3",
-        "tslib": "^2.5.0"
+        "@patternfly/react-icons": "^6.2.2",
+        "@patternfly/react-styles": "^6.2.2",
+        "@patternfly/react-tokens": "^6.2.2",
+        "focus-trap": "7.6.4",
+        "react-dropzone": "^14.3.5",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -3376,30 +3382,33 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.3.2.tgz",
-      "integrity": "sha512-GEygYbl0H4zD8nZuTQy2dayKIrV2bMMeWKSOEZ16Y3EYNgYVUOUnN+J0naAEuEGH39Xb1DE9n+XUbE1PC4CxPA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.2.2.tgz",
+      "integrity": "sha512-XkBwzuV/uiolX+T6QgB3RIqphM1m+vAZjAe3McYtyY22j1rsOdlWDE4RtRrJ1q7EoIZwyZHj0h8T9vMfUsLn4Q==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.3.1.tgz",
-      "integrity": "sha512-H6uBoFH3bJjD6PP75qZ4k+2TtF59vxf9sIVerPpwrGJcRgBZbvbMZCniSC3+S2LQ8DgXLnDvieq78jJzHz0hiA=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.2.2.tgz",
+      "integrity": "sha512-rncRDq66H8VnLyb9DrHHlZtPddlpNL9+W0XuQC0L7F6p78hOwSZmoGTW2Vq8/wJplDj8h/61qRpfRF9VEYPW0g==",
+      "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.3.4.tgz",
-      "integrity": "sha512-jGaiuo02scaC1HdGNHuYVRjtQCOB+vtvfbgS7nl1Y8ZcJ08wyUGhGSrEpNHfGAQ1XDSSoELAxj0cjOQwAAQw1A==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.2.2.tgz",
+      "integrity": "sha512-7CxVKhnpA+f8dLJ0hVvzZOe4Djx/nE+w70ipeAHf4Yi5JwfDWmbK97YvjYPfamp/bsXTLtPcK2n4AoY5DQX6Pg==",
+      "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "^5.3.4",
-        "@patternfly/react-icons": "^5.3.2",
-        "@patternfly/react-styles": "^5.3.1",
-        "@patternfly/react-tokens": "^5.3.1",
-        "lodash": "^4.17.19",
-        "tslib": "^2.5.0"
+        "@patternfly/react-core": "^6.2.2",
+        "@patternfly/react-icons": "^6.2.2",
+        "@patternfly/react-styles": "^6.2.2",
+        "@patternfly/react-tokens": "^6.2.2",
+        "lodash": "^4.17.21",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -3407,9 +3416,10 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.3.1.tgz",
-      "integrity": "sha512-VYK0uVP2/2RJ7ZshJCCLeq0Boih5I1bv+9Z/Bg6h12dCkLs85XsxAX9Ve+BGIo5DF54/mzcRHE1RKYap4ISXuw=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.2.2.tgz",
+      "integrity": "sha512-2GRWDPBTrcTlGNFc5NPJjrjEVU90RpgcGX/CIe2MplLgM32tpVIkeUtqIoJPLRk5GrbhyFuHJYRU+O93gU4o3Q==",
+      "license": "MIT"
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3504,28 +3514,30 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.14.tgz",
-      "integrity": "sha512-q3RgMJiJ4Zk4Qim0sKbCzn9IJtQT9oJWetu11FbHwYZV2w25mORM22QA9LS1jOsaywJJJc4J453CPVRBQhrkGw==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-6.0.7.tgz",
+      "integrity": "sha512-njhZMI1e/gLw3I4n8bLlO10ZmHk4rjPqHcyj159F0Z70v80QlwsCFVJcTde2fDMM5Eodkbo3xc2gCECA7TlZPg==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@patternfly/react-component-groups": "^5.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
-        "@redhat-cloud-services/types": "^1.0.9",
-        "@scalprum/core": "^0.7.0",
-        "@scalprum/react-core": "^0.8.0",
+        "@patternfly/react-component-groups": "^6.0.0",
+        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0",
+        "@redhat-cloud-services/types": "^2.0.0",
+        "@scalprum/core": "^0.8.1",
+        "@scalprum/react-core": "^0.9.1",
         "classnames": "^2.2.5",
-        "sanitize-html": "^2.12.1"
+        "sanitize-html": "^2.13.1"
       },
       "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-icons": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
+        "@patternfly/react-tokens": "^6.0.0",
         "lodash": "^4.17.15",
         "prop-types": "^15.6.2",
         "react": "^18.2.0",
         "react-content-loader": "^6.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": ">=7.0.0",
+        "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
@@ -3716,17 +3728,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3761,20 +3762,6 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
-    "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/@redhat-cloud-services/frontend-components-config/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3797,85 +3784,76 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-notifications": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-4.1.0.tgz",
-      "integrity": "sha512-bEoAeZMVY+UuSriSeruZ1pIesiPEjScrVFJQ5Wq/w3UFc79oXSYOgpRElxblPUH/LbKqp7inbzqRm2FxMcVxYg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-6.0.0.tgz",
+      "integrity": "sha512-FMNOAaTQz48R2D1wRjS0bb9/cMnyu++mweSDpWQ8vFRzvsgoOJXxNNOI6+bJpN6FOgP637rI7tiquWd2QLv+Aw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@redhat-cloud-services/frontend-components": "^4.0.9",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
-        "redux-promise-middleware": "6.1.3"
+        "@redhat-cloud-services/frontend-components": "^6.0.0",
+        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0"
       },
       "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "prop-types": "^15.6.2",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-icons": "^6.0.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": ">=7.2.9",
-        "redux": ">=4.2.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/redux-promise-middleware": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.3.tgz",
-      "integrity": "sha512-B/Hi5Ct5d9y5d/KG0f6MZUXKA0nrQh5583mHCx13HY3Avte8KfpoRH/TB5QT6k/FcjT6JCxjv7jedymidy2A1A==",
-      "peerDependencies": {
-        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0"
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.17.tgz",
-      "integrity": "sha512-A/KIw44ZRFzd/iLNF6hLWvKPyOvnpGCKwgsT3x9EhsJBS1I7KJU+g7h4M+XDy7vwDyUTIkfnTSbaaVdNnzmEFg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-6.0.5.tgz",
+      "integrity": "sha512-s5mnGuoP6VwYRHHSalAL7VJla2Xu2F+okFByHlYLUq9a95tVpzoDMsfeU7Oq7v3HwydoqwbewPIjSWtB05dJZQ==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
-        "@redhat-cloud-services/types": "^1.0.9",
-        "@sentry/browser": "^5.30.0",
+        "@redhat-cloud-services/types": "^2.0.0",
+        "@sentry/browser": "^7.119.1",
         "awesome-debounce-promise": "^2.1.0",
         "axios": "^0.28.1 || ^1.7.0",
         "commander": "^2.20.3",
         "mkdirp": "^1.0.4",
-        "p-all": "^5.0.0",
+        "p-map": "^7.0.2",
         "react-content-loader": "^6.2.0"
       },
       "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": ">=7.0.0",
+        "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
+    "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/p-map": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+      "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components-utilities/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+    "node_modules/@redhat-cloud-services/javascript-clients-shared": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/javascript-clients-shared/-/javascript-clients-shared-1.2.7.tgz",
+      "integrity": "sha512-DfH1Sdjwc9YYVM2wLznnNfC3+DFpdH8Ak59LW93KQWaPAn8ZHDoEXi/TZ8MisEgWTQv7jpsDVtlVQwOWkzKhUA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
+        "axios": "^1.7.2",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@redhat-cloud-services/rbac-client": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.4.5.tgz",
-      "integrity": "sha512-7kryZfzEYuw1V7c8bO5esXnfeYQO4Skz1XhluJ2whZNji8HcVbwDjBsQxy0+ndaSVirh5d86fufb00vK6fyUjw==",
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-2.2.11.tgz",
+      "integrity": "sha512-3LLW5XtBMqcdlYJ4lAFo7MaGnHXUBP01O3kty4ocU69EPjiip6/Gtj83vAx5hkgAWX9h6ZEntTDeDuU/ZfGdKQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "axios": "^0.27.2",
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.4",
+        "axios": "^1.7.2",
         "tslib": "^2.6.2"
       }
     },
@@ -3938,9 +3916,10 @@
       }
     },
     "node_modules/@redhat-cloud-services/types": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-1.0.12.tgz",
-      "integrity": "sha512-Ib4ZdgtWDgn3B/o2x/QuMu81X8HO+OmIcvgTAZl3rMyndg/c6g6cb95ZPs011c08oD5AQLptRiG/AsUVwOvkXQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-2.0.3.tgz",
+      "integrity": "sha512-tsubBSPwPwlK868Zr3xv9FbnjV9qb+l/8SwHj9ZP5NIlP/YWae81sTnGdRk+af+uX5PZo5AVV2JGzdSRJhPekw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@remix-run/router": {
       "version": "1.3.2",
@@ -3951,21 +3930,23 @@
       }
     },
     "node_modules/@scalprum/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-zvrPXexI+bxHGFY/teuwPI5yjnOuiq8uT+RDsrm3gnpr1AqZQVUiGdskl1ON/ci5lSs1kNadmXceF1BTKlicwg==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.8.3.tgz",
+      "integrity": "sha512-rg5ssFkJzFASPalVTzsKoLQ/H+WGGvQif1b7Ce/s1KVhFKWhqzdviUQCQ+yL5T4nRNi7ipnAuDAL4HfDKkyMGw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@scalprum/react-core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.8.0.tgz",
-      "integrity": "sha512-ADqL6GdjT0ihVfTtIqu8vvYgwUb3IiUGXj9md1+h6tL8yshbq+FAezwuD9jhX7qcjfgL1Sl3g/faO2/SE9jPvw==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.9.5.tgz",
+      "integrity": "sha512-Z468yqlnjCL66Dkj5qAPKGkzhDs/dcyouMR3833BVOecG/G1f8temOXX20ztAMxqk7Hf7Wa0zvR1KFk0hGgEyA==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@scalprum/core": "^0.7.0",
+        "@scalprum/core": "^0.8.3",
         "lodash": "^4.17.0"
       },
       "peerDependencies": {
@@ -3973,105 +3954,131 @@
         "react-dom": ">=16.8.0 || >=17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/@sentry/browser": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
-      "integrity": "sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==",
+    "node_modules/@sentry-internal/feedback": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.3.tgz",
+      "integrity": "sha512-ewJJIQ0mbsOX6jfiVFvqMjokxNtgP3dNwUv+4nenN+iJJPQsM6a0ocro3iscxwVdbkjw5hY3BUV2ICI5Q0UWoA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/core": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
-    "node_modules/@sentry/browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.3.tgz",
+      "integrity": "sha512-s5xy+bVL1eDZchM6gmaOiXvTqpAsUfO7122DxVdEDMtwVq3e22bS2aiGa8CUgOiJkulZ+09q73nufM77kOmT/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.3",
+        "@sentry/replay": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.3.tgz",
+      "integrity": "sha512-Ausx+Jw1pAMbIBHStoQ6ZqDZR60PsCByvHdw/jdH9AqPrNE9xlBSf9EwcycvmrzwyKspSLaB52grlje2cRIUMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.3.tgz",
+      "integrity": "sha512-i9vGcK9N8zZ/JQo1TCEfHHYZ2miidOvgOABRUc9zQKhYdcYQB2/LU1kqlj77Pxdxf4wOa9137d6rPrSn9iiBxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/feedback": "7.120.3",
+        "@sentry-internal/replay-canvas": "7.120.3",
+        "@sentry-internal/tracing": "7.120.3",
+        "@sentry/core": "7.120.3",
+        "@sentry/integrations": "7.120.3",
+        "@sentry/replay": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@sentry/core": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.3.tgz",
+      "integrity": "sha512-vyy11fCGpkGK3qI5DSXOjgIboBZTriw0YDx/0KyX5CjIjDDNgp5AGgpgFkfZyiYiaU2Ww3iFuKo4wHmBusz1uA==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
-    "node_modules/@sentry/core/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/hub": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
-      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+    "node_modules/@sentry/integrations": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.3.tgz",
+      "integrity": "sha512-6i/lYp0BubHPDTg91/uxHvNui427df9r17SsIEXa2eKDwQ9gW2qRx5IWgvnxs2GV/GfSbwcx4swUB3RfEWrXrQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry/core": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3",
+        "localforage": "^1.8.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
-    "node_modules/@sentry/hub/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-    },
-    "node_modules/@sentry/minimal": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
-      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+    "node_modules/@sentry/replay": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.3.tgz",
+      "integrity": "sha512-CjVq1fP6bpDiX8VQxudD5MPWwatfXk8EJ2jQhJTcWu/4bCSOQmHxnnmBM+GVn5acKUBCodWHBN+IUZgnJheZSg==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry-internal/tracing": "7.120.3",
+        "@sentry/core": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
-    },
-    "node_modules/@sentry/minimal/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sentry/types": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==",
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.3.tgz",
+      "integrity": "sha512-C4z+3kGWNFJ303FC+FxAd4KkHvxpNFYAFN8iMIgBwJdpIl25KZ8Q/VdGn0MLLUEHNLvjob0+wvwlcRBBNLXOow==",
+      "license": "MIT",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
-      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.3.tgz",
+      "integrity": "sha512-UDAOQJtJDxZHQ5Nm1olycBIsz2wdGX8SdzyGVHmD8EOQYAeDZQyIlQYohDe9nazdIOQLZCIc3fU0G9gqVLkaGQ==",
+      "license": "MIT",
       "dependencies": {
-        "@sentry/types": "5.30.0",
-        "tslib": "^1.9.3"
+        "@sentry/types": "7.120.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
-    },
-    "node_modules/@sentry/utils/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
@@ -4626,7 +4633,8 @@
     "node_modules/@types/debounce-promise": {
       "version": "3.1.9",
       "resolved": "https://registry.npmjs.org/@types/debounce-promise/-/debounce-promise-3.1.9.tgz",
-      "integrity": "sha512-awNxydYSU+E2vL7EiOAMtiSOfL5gUM5X4YSE2A92qpxDJQ/rXz6oMPYBFDcDywlUmvIDI6zsqgq17cGm5CITQw=="
+      "integrity": "sha512-awNxydYSU+E2vL7EiOAMtiSOfL5gUM5X4YSE2A92qpxDJQ/rXz6oMPYBFDcDywlUmvIDI6zsqgq17cGm5CITQw==",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -5915,9 +5923,10 @@
       }
     },
     "node_modules/attr-accept": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
-      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -5941,6 +5950,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/awesome-debounce-promise/-/awesome-debounce-promise-2.1.0.tgz",
       "integrity": "sha512-0Dv4j2wKk5BrNZh4jgV2HUdznaeVgEK/WTvcHhZWUElhmQ1RR+iURRoLEwICFyR0S/5VtxfcvY6gR+qSe95jNg==",
+      "license": "MIT",
       "dependencies": {
         "@types/debounce-promise": "^3.1.1",
         "awesome-imperative-promise": "^1.0.1",
@@ -5956,6 +5966,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/awesome-imperative-promise/-/awesome-imperative-promise-1.0.1.tgz",
       "integrity": "sha512-EmPr3FqbQGqlNh+WxMNcF9pO9uDQJnOC4/3rLBQNH9m4E9qI+8lbfHCmHpVAsmGqPJPKhCjJLHUQzQW/RBHRdQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=8",
         "npm": ">=5"
@@ -5965,6 +5976,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/awesome-only-resolves-last-promise/-/awesome-only-resolves-last-promise-1.0.3.tgz",
       "integrity": "sha512-7q4WPsYiD8Omvi/yHL314DkvsD/lM//Z2/KcU1vWk0xJotiV0GMJTgHTpWl3n90HJqpXKg7qX+VVNs5YbQyPRQ==",
+      "license": "MIT",
       "dependencies": {
         "awesome-imperative-promise": "^1.0.1"
       },
@@ -5974,21 +5986,25 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -6420,6 +6436,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -6660,6 +6689,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -7058,6 +7088,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/css-jss/-/css-jss-10.10.0.tgz",
       "integrity": "sha512-YyMIS/LsSKEGXEaVJdjonWe18p4vXLo8CMA4FrW/kcaEyqdIGKCFXao31gbJddXEdIxSXFFURWrenBJPlKTgAA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "^10.10.0",
@@ -7145,6 +7176,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.8.tgz",
       "integrity": "sha512-x9Aq0XTInxrkuFeHKbYC7zWY8ai7qJ04Kxd9MnvbC1uO5DagxoHQjm4JvG+vCdXOoFtCjbL2XSZfxmoYa9uQVQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.3",
         "is-in-browser": "^1.0.2"
@@ -7248,7 +7280,8 @@
     "node_modules/debounce-promise": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/debounce-promise/-/debounce-promise-3.1.2.tgz",
-      "integrity": "sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg=="
+      "integrity": "sha512-rZHcgBkbYavBeD9ej6sP56XfG53d51CD4dnaw989YX/nZ/ZJfgRx/9ePKmTNiUiyQvh4mtrMoS3OAWW+yoYtpg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -7706,6 +7739,20 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -7867,13 +7914,10 @@
       }
     },
     "node_modules/es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       }
@@ -7882,7 +7926,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -7918,6 +7961,33 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
       "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
       "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/es-shim-unscopables": {
       "version": "1.0.0",
@@ -8892,11 +8962,12 @@
       }
     },
     "node_modules/file-selector": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
-      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
       "dependencies": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.7.0"
       },
       "engines": {
         "node": ">= 12"
@@ -8980,9 +9051,10 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
-      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
+      "license": "MIT",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -9266,7 +9338,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9323,16 +9394,21 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -9348,6 +9424,19 @@
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -9486,12 +9575,12 @@
       }
     },
     "node_modules/gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -9573,23 +9662,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
@@ -9601,7 +9678,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -9616,7 +9692,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -10061,7 +10136,8 @@
     "node_modules/hyphenate-style-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
-      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw=="
+      "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -10127,6 +10203,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/immutable": {
       "version": "5.1.1",
@@ -10541,7 +10623,8 @@
     "node_modules/is-in-browser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
+      "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g==",
+      "license": "MIT"
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
@@ -10688,6 +10771,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13087,6 +13171,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss/-/jss-10.10.0.tgz",
       "integrity": "sha512-cqsOTS7jqPsPMjtKYDUpdFC0AbhYFLTcuGRqymgmdJIeQ8cH7+AgX7YSgQy79wXloZq2VvATYxUOUQEvS1V/Zw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "csstype": "^3.0.2",
@@ -13102,6 +13187,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.10.0.tgz",
       "integrity": "sha512-z+HETfj5IYgFxh1wJnUAU8jByI48ED+v0fuTuhKrPR+pRBYS2EDwbusU8aFOpCdYhtRc9zhN+PJ7iNE8pAWyPw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
@@ -13112,6 +13198,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-compose/-/jss-plugin-compose-10.10.0.tgz",
       "integrity": "sha512-F5kgtWpI2XfZ3Z8eP78tZEYFdgTIbpA/TMuX3a8vwrNolYtN1N4qJR/Ob0LAsqIwCMLojtxN7c7Oo/+Vz6THow==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -13122,6 +13209,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-default-unit/-/jss-plugin-default-unit-10.10.0.tgz",
       "integrity": "sha512-SvpajxIECi4JDUbGLefvNckmI+c2VWmP43qnEy/0eiwzRUsafg5DVSIWSzZe4d2vFX1u9nRDP46WCFV/PXVBGQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0"
@@ -13131,6 +13219,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-expand/-/jss-plugin-expand-10.10.0.tgz",
       "integrity": "sha512-ymT62W2OyDxBxr7A6JR87vVX9vTq2ep5jZLIdUSusfBIEENLdkkc0lL/Xaq8W9s3opUq7R0sZQpzRWELrfVYzA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0"
@@ -13140,6 +13229,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-extend/-/jss-plugin-extend-10.10.0.tgz",
       "integrity": "sha512-sKYrcMfr4xxigmIwqTjxNcHwXJIfvhvjTNxF+Tbc1NmNdyspGW47Ey6sGH8BcQ4FFQhLXctpWCQSpDwdNmXSwg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -13150,6 +13240,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-global/-/jss-plugin-global-10.10.0.tgz",
       "integrity": "sha512-icXEYbMufiNuWfuazLeN+BNJO16Ge88OcXU5ZDC2vLqElmMybA31Wi7lZ3lf+vgufRocvPj8443irhYRgWxP+A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0"
@@ -13159,6 +13250,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-nested/-/jss-plugin-nested-10.10.0.tgz",
       "integrity": "sha512-9R4JHxxGgiZhurDo3q7LdIiDEgtA1bTGzAbhSPyIOWb7ZubrjQe8acwhEQ6OEKydzpl8XHMtTnEwHXCARLYqYA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -13169,6 +13261,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-props-sort/-/jss-plugin-props-sort-10.10.0.tgz",
       "integrity": "sha512-5VNJvQJbnq/vRfje6uZLe/FyaOpzP/IH1LP+0fr88QamVrGJa0hpRRyAa0ea4U/3LcorJfBFVyC4yN2QC73lJg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0"
@@ -13178,6 +13271,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.10.0.tgz",
       "integrity": "sha512-uEFJFgaCtkXeIPgki8ICw3Y7VMkL9GEan6SqmT9tqpwM+/t+hxfMUdU4wQ0MtOiMNWhwnckBV0IebrKcZM9C0g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -13188,6 +13282,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-rule-value-observable/-/jss-plugin-rule-value-observable-10.10.0.tgz",
       "integrity": "sha512-ZLMaYrR3QE+vD7nl3oNXuj79VZl9Kp8/u6A1IbTPDcuOu8b56cFdWRZNZ0vNr8jHewooEeq2doy8Oxtymr2ZPA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -13198,6 +13293,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-template/-/jss-plugin-template-10.10.0.tgz",
       "integrity": "sha512-ocXZBIOJOA+jISPdsgkTs8wwpK6UbsvtZK5JI7VUggTD6LWKbtoxUzadd2TpfF+lEtlhUmMsCkTRNkITdPKa6w==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -13208,6 +13304,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.10.0.tgz",
       "integrity": "sha512-UY/41WumgjW8r1qMCO8l1ARg7NHnfRVWRhZ2E2m0DMYsr2DD91qIXLyNhiX83hHswR7Wm4D+oDYNC1zWCJWtqg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "css-vendor": "^2.0.8",
@@ -13218,6 +13315,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-10.10.0.tgz",
       "integrity": "sha512-GL175Wt2FGhjE+f+Y3aWh+JioL06/QWFgZp53CbNNq6ZkVU0TDplD8Bxm9KnkotAYn3FlplNqoW5CjyLXcoJ7Q==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.10.0",
@@ -13320,6 +13418,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -13393,6 +13500,15 @@
       },
       "engines": {
         "node": ">=8.9.0"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lie": "3.1.1"
       }
     },
     "node_modules/locate-path": {
@@ -13580,6 +13696,15 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -13763,6 +13888,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -14413,31 +14539,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/p-all": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-all/-/p-all-5.0.0.tgz",
-      "integrity": "sha512-pofqu/1FhCVa+78xNAptCGc9V45exFz2pvBRyIvgXkNM0Rh18Py7j8pQuSjA+zpabI46v9hRjNWmL9EAFcEbpw==",
-      "dependencies": {
-        "p-map": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-all/node_modules/p-map": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
-      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -14551,7 +14652,8 @@
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -15153,7 +15255,8 @@
     "node_modules/react-display-name": {
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/react-display-name/-/react-display-name-0.2.5.tgz",
-      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg=="
+      "integrity": "sha512-I+vcaK9t4+kypiSgaiVWAipqHRXYmZIuAiS8vzFvXHHXVigg/sMKwlRgLy6LH2i3rmP+0Vzfl5lFsFRwF1r3pg==",
+      "license": "MIT"
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
@@ -15168,12 +15271,13 @@
       }
     },
     "node_modules/react-dropzone": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
-      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "version": "14.3.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
+      "license": "MIT",
       "dependencies": {
-        "attr-accept": "^2.2.2",
-        "file-selector": "^0.6.0",
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -15187,6 +15291,7 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -15196,7 +15301,8 @@
     "node_modules/react-dropzone/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -15207,6 +15313,7 @@
       "version": "10.10.0",
       "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-10.10.0.tgz",
       "integrity": "sha512-WLiq84UYWqNBF6579/uprcIUnM1TSywYq6AIjKTTTG5ziJl9Uy+pwuvpN3apuyVwflMbD60PraeTKT7uWH9XEQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.3.1",
         "@emotion/is-prop-valid": "^0.7.3",
@@ -15722,9 +15829,10 @@
       "dev": true
     },
     "node_modules/sanitize-html": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
-      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.16.0.tgz",
+      "integrity": "sha512-0s4caLuHHaZFVxFTG74oW91+j6vW7gKbGD6CD2+miP73CE6z6YtOBN0ArtLd2UGyi4IC7K47v3ENUbQX4jV3Mg==",
+      "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -15738,6 +15846,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
       "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.2",
@@ -15751,6 +15860,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
       "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "domelementtype": "^2.3.0"
       },
@@ -15762,9 +15872,10 @@
       }
     },
     "node_modules/sanitize-html/node_modules/domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -15778,6 +15889,7 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
       "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -15789,6 +15901,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -15807,6 +15920,7 @@
           "url": "https://github.com/sponsors/fb55"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
@@ -16189,7 +16303,8 @@
     "node_modules/shallow-equal": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
-      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -16765,6 +16880,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.2.0.tgz",
       "integrity": "sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16778,7 +16894,8 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -16883,6 +17000,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/theming/-/theming-3.3.0.tgz",
       "integrity": "sha512-u6l4qTJRDaWZsqa8JugaNt7Xd8PPl9+gonZaIe28vAhqgHMIG/DOyFPqiKN/gQLQYj05tHv+YQdNILL4zoiAVA==",
+      "license": "MIT",
       "dependencies": {
         "hoist-non-react-statics": "^3.3.0",
         "prop-types": "^15.5.8",
@@ -16931,7 +17049,8 @@
     "node_modules/tiny-warning": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
+      "license": "MIT"
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -17260,9 +17379,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -17639,31 +17759,6 @@
       },
       "engines": {
         "node": ">=12.0.0"
-      }
-    },
-    "node_modules/wait-on/node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-      "dev": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/wait-on/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/walker": {
@@ -20600,9 +20695,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "7.6.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-          "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="
+          "version": "7.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+          "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
         }
       }
     },
@@ -20743,58 +20838,58 @@
       "optional": true
     },
     "@patternfly/react-component-groups": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.2.0.tgz",
-      "integrity": "sha512-kb57OOVJ9L5fbY/kiil8awPWuJVops8Rz1ZNFtkEb72mF3lhmRadYNheLBeaD8T9GE1dOaVJRMMf133ZSKN87g==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-6.2.1.tgz",
+      "integrity": "sha512-bPiPoVOR+mS3xdMpAv/xkbT9+PVvNhfE22JdUG2pfmWXXTP7BsmFgRo4mouSDqqDTdXz+ZDYKRkxGR5FpKMJyQ==",
       "requires": {
-        "@patternfly/react-core": "^5.1.1",
-        "@patternfly/react-icons": "^5.1.1",
-        "@patternfly/react-table": "^5.1.1",
-        "clsx": "^2.0.0",
+        "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-icons": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
+        "clsx": "^2.1.1",
         "react-jss": "^10.10.0"
       }
     },
     "@patternfly/react-core": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.3.4.tgz",
-      "integrity": "sha512-zr2yeilIoFp8MFOo0vNgI8XuM+P2466zHvy4smyRNRH2/but2WObqx7Wu4ftd/eBMYdNqmTeuXe6JeqqRqnPMQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.2.2.tgz",
+      "integrity": "sha512-JUrZ57JQ4bkmed1kxaciXb0ZpIVYyCHc2HjtzoKQ5UNRlx204zR2isATSHjdw2GFcWvwpkC5/fU2BR+oT3opbg==",
       "requires": {
-        "@patternfly/react-icons": "^5.3.2",
-        "@patternfly/react-styles": "^5.3.1",
-        "@patternfly/react-tokens": "^5.3.1",
-        "focus-trap": "7.5.2",
-        "react-dropzone": "^14.2.3",
-        "tslib": "^2.5.0"
+        "@patternfly/react-icons": "^6.2.2",
+        "@patternfly/react-styles": "^6.2.2",
+        "@patternfly/react-tokens": "^6.2.2",
+        "focus-trap": "7.6.4",
+        "react-dropzone": "^14.3.5",
+        "tslib": "^2.8.1"
       }
     },
     "@patternfly/react-icons": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.3.2.tgz",
-      "integrity": "sha512-GEygYbl0H4zD8nZuTQy2dayKIrV2bMMeWKSOEZ16Y3EYNgYVUOUnN+J0naAEuEGH39Xb1DE9n+XUbE1PC4CxPA==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.2.2.tgz",
+      "integrity": "sha512-XkBwzuV/uiolX+T6QgB3RIqphM1m+vAZjAe3McYtyY22j1rsOdlWDE4RtRrJ1q7EoIZwyZHj0h8T9vMfUsLn4Q==",
       "requires": {}
     },
     "@patternfly/react-styles": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.3.1.tgz",
-      "integrity": "sha512-H6uBoFH3bJjD6PP75qZ4k+2TtF59vxf9sIVerPpwrGJcRgBZbvbMZCniSC3+S2LQ8DgXLnDvieq78jJzHz0hiA=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.2.2.tgz",
+      "integrity": "sha512-rncRDq66H8VnLyb9DrHHlZtPddlpNL9+W0XuQC0L7F6p78hOwSZmoGTW2Vq8/wJplDj8h/61qRpfRF9VEYPW0g=="
     },
     "@patternfly/react-table": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.3.4.tgz",
-      "integrity": "sha512-jGaiuo02scaC1HdGNHuYVRjtQCOB+vtvfbgS7nl1Y8ZcJ08wyUGhGSrEpNHfGAQ1XDSSoELAxj0cjOQwAAQw1A==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.2.2.tgz",
+      "integrity": "sha512-7CxVKhnpA+f8dLJ0hVvzZOe4Djx/nE+w70ipeAHf4Yi5JwfDWmbK97YvjYPfamp/bsXTLtPcK2n4AoY5DQX6Pg==",
       "requires": {
-        "@patternfly/react-core": "^5.3.4",
-        "@patternfly/react-icons": "^5.3.2",
-        "@patternfly/react-styles": "^5.3.1",
-        "@patternfly/react-tokens": "^5.3.1",
-        "lodash": "^4.17.19",
-        "tslib": "^2.5.0"
+        "@patternfly/react-core": "^6.2.2",
+        "@patternfly/react-icons": "^6.2.2",
+        "@patternfly/react-styles": "^6.2.2",
+        "@patternfly/react-tokens": "^6.2.2",
+        "lodash": "^4.17.21",
+        "tslib": "^2.8.1"
       }
     },
     "@patternfly/react-tokens": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.3.1.tgz",
-      "integrity": "sha512-VYK0uVP2/2RJ7ZshJCCLeq0Boih5I1bv+9Z/Bg6h12dCkLs85XsxAX9Ve+BGIo5DF54/mzcRHE1RKYap4ISXuw=="
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.2.2.tgz",
+      "integrity": "sha512-2GRWDPBTrcTlGNFc5NPJjrjEVU90RpgcGX/CIe2MplLgM32tpVIkeUtqIoJPLRk5GrbhyFuHJYRU+O93gU4o3Q=="
     },
     "@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -20847,17 +20942,17 @@
       }
     },
     "@redhat-cloud-services/frontend-components": {
-      "version": "4.2.14",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.14.tgz",
-      "integrity": "sha512-q3RgMJiJ4Zk4Qim0sKbCzn9IJtQT9oJWetu11FbHwYZV2w25mORM22QA9LS1jOsaywJJJc4J453CPVRBQhrkGw==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-6.0.7.tgz",
+      "integrity": "sha512-njhZMI1e/gLw3I4n8bLlO10ZmHk4rjPqHcyj159F0Z70v80QlwsCFVJcTde2fDMM5Eodkbo3xc2gCECA7TlZPg==",
       "requires": {
-        "@patternfly/react-component-groups": "^5.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
-        "@redhat-cloud-services/types": "^1.0.9",
-        "@scalprum/core": "^0.7.0",
-        "@scalprum/react-core": "^0.8.0",
+        "@patternfly/react-component-groups": "^6.0.0",
+        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0",
+        "@redhat-cloud-services/types": "^2.0.0",
+        "@scalprum/core": "^0.8.1",
+        "@scalprum/react-core": "^0.9.1",
         "classnames": "^2.2.5",
-        "sanitize-html": "^2.12.1"
+        "sanitize-html": "^2.13.1"
       }
     },
     "@redhat-cloud-services/frontend-components-config": {
@@ -20919,17 +21014,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "axios": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-          "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -20954,17 +21038,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
         },
         "has-flag": {
           "version": "4.0.0",
@@ -21067,67 +21140,53 @@
       }
     },
     "@redhat-cloud-services/frontend-components-notifications": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-4.1.0.tgz",
-      "integrity": "sha512-bEoAeZMVY+UuSriSeruZ1pIesiPEjScrVFJQ5Wq/w3UFc79oXSYOgpRElxblPUH/LbKqp7inbzqRm2FxMcVxYg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-6.0.0.tgz",
+      "integrity": "sha512-FMNOAaTQz48R2D1wRjS0bb9/cMnyu++mweSDpWQ8vFRzvsgoOJXxNNOI6+bJpN6FOgP637rI7tiquWd2QLv+Aw==",
       "requires": {
-        "@redhat-cloud-services/frontend-components": "^4.0.9",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.2",
-        "redux-promise-middleware": "6.1.3"
-      },
-      "dependencies": {
-        "redux-promise-middleware": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.3.tgz",
-          "integrity": "sha512-B/Hi5Ct5d9y5d/KG0f6MZUXKA0nrQh5583mHCx13HY3Avte8KfpoRH/TB5QT6k/FcjT6JCxjv7jedymidy2A1A==",
-          "requires": {}
-        }
+        "@redhat-cloud-services/frontend-components": "^6.0.0",
+        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0"
       }
     },
     "@redhat-cloud-services/frontend-components-utilities": {
-      "version": "4.0.17",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.17.tgz",
-      "integrity": "sha512-A/KIw44ZRFzd/iLNF6hLWvKPyOvnpGCKwgsT3x9EhsJBS1I7KJU+g7h4M+XDy7vwDyUTIkfnTSbaaVdNnzmEFg==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-6.0.5.tgz",
+      "integrity": "sha512-s5mnGuoP6VwYRHHSalAL7VJla2Xu2F+okFByHlYLUq9a95tVpzoDMsfeU7Oq7v3HwydoqwbewPIjSWtB05dJZQ==",
       "requires": {
         "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
-        "@redhat-cloud-services/types": "^1.0.9",
-        "@sentry/browser": "^5.30.0",
+        "@redhat-cloud-services/types": "^2.0.0",
+        "@sentry/browser": "^7.119.1",
         "awesome-debounce-promise": "^2.1.0",
         "axios": "^0.28.1 || ^1.7.0",
         "commander": "^2.20.3",
         "mkdirp": "^1.0.4",
-        "p-all": "^5.0.0",
+        "p-map": "^7.0.2",
         "react-content-loader": "^6.2.0"
       },
       "dependencies": {
-        "axios": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-          "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
+        "p-map": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
+          "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA=="
         }
       }
     },
-    "@redhat-cloud-services/rbac-client": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-1.4.5.tgz",
-      "integrity": "sha512-7kryZfzEYuw1V7c8bO5esXnfeYQO4Skz1XhluJ2whZNji8HcVbwDjBsQxy0+ndaSVirh5d86fufb00vK6fyUjw==",
+    "@redhat-cloud-services/javascript-clients-shared": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/javascript-clients-shared/-/javascript-clients-shared-1.2.7.tgz",
+      "integrity": "sha512-DfH1Sdjwc9YYVM2wLznnNfC3+DFpdH8Ak59LW93KQWaPAn8ZHDoEXi/TZ8MisEgWTQv7jpsDVtlVQwOWkzKhUA==",
       "requires": {
-        "axios": "^0.27.2",
+        "axios": "^1.7.2",
+        "tslib": "^2.6.2"
+      }
+    },
+    "@redhat-cloud-services/rbac-client": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/rbac-client/-/rbac-client-2.2.11.tgz",
+      "integrity": "sha512-3LLW5XtBMqcdlYJ4lAFo7MaGnHXUBP01O3kty4ocU69EPjiip6/Gtj83vAx5hkgAWX9h6ZEntTDeDuU/ZfGdKQ==",
+      "requires": {
+        "@redhat-cloud-services/javascript-clients-shared": "^1.2.4",
+        "axios": "^1.7.2",
         "tslib": "^2.6.2"
       }
     },
@@ -21174,9 +21233,9 @@
       }
     },
     "@redhat-cloud-services/types": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-1.0.12.tgz",
-      "integrity": "sha512-Ib4ZdgtWDgn3B/o2x/QuMu81X8HO+OmIcvgTAZl3rMyndg/c6g6cb95ZPs011c08oD5AQLptRiG/AsUVwOvkXQ=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/types/-/types-2.0.3.tgz",
+      "integrity": "sha512-tsubBSPwPwlK868Zr3xv9FbnjV9qb+l/8SwHj9ZP5NIlP/YWae81sTnGdRk+af+uX5PZo5AVV2JGzdSRJhPekw=="
     },
     "@remix-run/router": {
       "version": "1.3.2",
@@ -21184,114 +21243,112 @@
       "integrity": "sha512-t54ONhl/h75X94SWsHGQ4G/ZrCEguKSRQr7DrjTciJXW0YU1QhlwYeycvK5JgkzlxmvrK7wq1NB/PLtHxoiDcA=="
     },
     "@scalprum/core": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.7.0.tgz",
-      "integrity": "sha512-zvrPXexI+bxHGFY/teuwPI5yjnOuiq8uT+RDsrm3gnpr1AqZQVUiGdskl1ON/ci5lSs1kNadmXceF1BTKlicwg==",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@scalprum/core/-/core-0.8.3.tgz",
+      "integrity": "sha512-rg5ssFkJzFASPalVTzsKoLQ/H+WGGvQif1b7Ce/s1KVhFKWhqzdviUQCQ+yL5T4nRNi7ipnAuDAL4HfDKkyMGw==",
       "requires": {
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
         "tslib": "^2.6.2"
       }
     },
     "@scalprum/react-core": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.8.0.tgz",
-      "integrity": "sha512-ADqL6GdjT0ihVfTtIqu8vvYgwUb3IiUGXj9md1+h6tL8yshbq+FAezwuD9jhX7qcjfgL1Sl3g/faO2/SE9jPvw==",
+      "version": "0.9.5",
+      "resolved": "https://registry.npmjs.org/@scalprum/react-core/-/react-core-0.9.5.tgz",
+      "integrity": "sha512-Z468yqlnjCL66Dkj5qAPKGkzhDs/dcyouMR3833BVOecG/G1f8temOXX20ztAMxqk7Hf7Wa0zvR1KFk0hGgEyA==",
       "requires": {
         "@openshift/dynamic-plugin-sdk": "^5.0.1",
-        "@scalprum/core": "^0.7.0",
+        "@scalprum/core": "^0.8.3",
         "lodash": "^4.17.0"
       }
     },
-    "@sentry/browser": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.30.0.tgz",
-      "integrity": "sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==",
+    "@sentry-internal/feedback": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-7.120.3.tgz",
+      "integrity": "sha512-ewJJIQ0mbsOX6jfiVFvqMjokxNtgP3dNwUv+4nenN+iJJPQsM6a0ocro3iscxwVdbkjw5hY3BUV2ICI5Q0UWoA==",
       "requires": {
-        "@sentry/core": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/core": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
+      }
+    },
+    "@sentry-internal/replay-canvas": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-7.120.3.tgz",
+      "integrity": "sha512-s5xy+bVL1eDZchM6gmaOiXvTqpAsUfO7122DxVdEDMtwVq3e22bS2aiGa8CUgOiJkulZ+09q73nufM77kOmT/A==",
+      "requires": {
+        "@sentry/core": "7.120.3",
+        "@sentry/replay": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
+      }
+    },
+    "@sentry-internal/tracing": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.120.3.tgz",
+      "integrity": "sha512-Ausx+Jw1pAMbIBHStoQ6ZqDZR60PsCByvHdw/jdH9AqPrNE9xlBSf9EwcycvmrzwyKspSLaB52grlje2cRIUMg==",
+      "requires": {
+        "@sentry/core": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
+      }
+    },
+    "@sentry/browser": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-7.120.3.tgz",
+      "integrity": "sha512-i9vGcK9N8zZ/JQo1TCEfHHYZ2miidOvgOABRUc9zQKhYdcYQB2/LU1kqlj77Pxdxf4wOa9137d6rPrSn9iiBxg==",
+      "requires": {
+        "@sentry-internal/feedback": "7.120.3",
+        "@sentry-internal/replay-canvas": "7.120.3",
+        "@sentry-internal/tracing": "7.120.3",
+        "@sentry/core": "7.120.3",
+        "@sentry/integrations": "7.120.3",
+        "@sentry/replay": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
       }
     },
     "@sentry/core": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.30.0.tgz",
-      "integrity": "sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==",
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.120.3.tgz",
+      "integrity": "sha512-vyy11fCGpkGK3qI5DSXOjgIboBZTriw0YDx/0KyX5CjIjDDNgp5AGgpgFkfZyiYiaU2Ww3iFuKo4wHmBusz1uA==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/minimal": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
       }
     },
-    "@sentry/hub": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.30.0.tgz",
-      "integrity": "sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==",
+    "@sentry/integrations": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.120.3.tgz",
+      "integrity": "sha512-6i/lYp0BubHPDTg91/uxHvNui427df9r17SsIEXa2eKDwQ9gW2qRx5IWgvnxs2GV/GfSbwcx4swUB3RfEWrXrQ==",
       "requires": {
-        "@sentry/types": "5.30.0",
-        "@sentry/utils": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/core": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3",
+        "localforage": "^1.8.1"
       }
     },
-    "@sentry/minimal": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.30.0.tgz",
-      "integrity": "sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==",
+    "@sentry/replay": {
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-7.120.3.tgz",
+      "integrity": "sha512-CjVq1fP6bpDiX8VQxudD5MPWwatfXk8EJ2jQhJTcWu/4bCSOQmHxnnmBM+GVn5acKUBCodWHBN+IUZgnJheZSg==",
       "requires": {
-        "@sentry/hub": "5.30.0",
-        "@sentry/types": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry-internal/tracing": "7.120.3",
+        "@sentry/core": "7.120.3",
+        "@sentry/types": "7.120.3",
+        "@sentry/utils": "7.120.3"
       }
     },
     "@sentry/types": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.30.0.tgz",
-      "integrity": "sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw=="
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.120.3.tgz",
+      "integrity": "sha512-C4z+3kGWNFJ303FC+FxAd4KkHvxpNFYAFN8iMIgBwJdpIl25KZ8Q/VdGn0MLLUEHNLvjob0+wvwlcRBBNLXOow=="
     },
     "@sentry/utils": {
-      "version": "5.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.30.0.tgz",
-      "integrity": "sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==",
+      "version": "7.120.3",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.120.3.tgz",
+      "integrity": "sha512-UDAOQJtJDxZHQ5Nm1olycBIsz2wdGX8SdzyGVHmD8EOQYAeDZQyIlQYohDe9nazdIOQLZCIc3fU0G9gqVLkaGQ==",
       "requires": {
-        "@sentry/types": "5.30.0",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-        }
+        "@sentry/types": "7.120.3"
       }
     },
     "@sideway/address": {
@@ -22708,9 +22765,9 @@
       "dev": true
     },
     "attr-accept": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.2.tgz",
-      "integrity": "sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg=="
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
+      "integrity": "sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ=="
     },
     "available-typed-arrays": {
       "version": "1.0.7",
@@ -22746,21 +22803,23 @@
       }
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       },
       "dependencies": {
         "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+          "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
+            "es-set-tostringtag": "^2.1.0",
             "mime-types": "^2.1.12"
           }
         }
@@ -23069,6 +23128,15 @@
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
         "set-function-length": "^1.2.1"
+      }
+    },
+    "call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
       }
     },
     "callsites": {
@@ -24015,6 +24083,16 @@
         "tslib": "^2.0.3"
       }
     },
+    "dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "requires": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      }
+    },
     "duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -24145,19 +24223,14 @@
       }
     },
     "es-define-property": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.2.4"
-      }
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="
     },
     "es-errors": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="
     },
     "es-get-iterator": {
       "version": "1.1.3",
@@ -24189,6 +24262,25 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.3.0.tgz",
       "integrity": "sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==",
       "dev": true
+    },
+    "es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "requires": {
+        "es-errors": "^1.3.0"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "requires": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      }
     },
     "es-shim-unscopables": {
       "version": "1.0.0",
@@ -24910,11 +25002,11 @@
       }
     },
     "file-selector": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-0.6.0.tgz",
-      "integrity": "sha512-QlZ5yJC0VxHxQQsQhXvBaC7VRJ2uaxTf+Tfpu4Z/OcVQJVpZO+DGU0rkoVW5ce2SccxugvpBJoMvUs59iILYdw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
       "requires": {
-        "tslib": "^2.4.0"
+        "tslib": "^2.7.0"
       }
     },
     "fill-range": {
@@ -24985,9 +25077,9 @@
       "dev": true
     },
     "focus-trap": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
-      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
       "requires": {
         "tabbable": "^6.2.0"
       }
@@ -25176,8 +25268,7 @@
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "function.prototype.name": {
       "version": "1.1.5",
@@ -25216,16 +25307,20 @@
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
-      "dev": true,
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "requires": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       }
     },
     "get-package-type": {
@@ -25233,6 +25328,15 @@
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
+    },
+    "get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "requires": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      }
     },
     "get-stream": {
       "version": "6.0.1",
@@ -25329,13 +25433,9 @@
       }
     },
     "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.3"
-      }
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
     "graceful-fs": {
       "version": "4.2.11",
@@ -25394,23 +25494,15 @@
         "es-define-property": "^1.0.0"
       }
     },
-    "has-proto": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "dev": true
-    },
     "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="
     },
     "has-tostringtag": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "requires": {
         "has-symbols": "^1.0.3"
       }
@@ -25419,7 +25511,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -25794,6 +25885,11 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "dev": true
+    },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
     },
     "immutable": {
       "version": "5.1.1",
@@ -28165,6 +28261,14 @@
         "type-check": "~0.4.0"
       }
     },
+    "lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
+    },
     "lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -28222,6 +28326,14 @@
         "big.js": "^5.2.2",
         "emojis-list": "^3.0.0",
         "json5": "^2.1.2"
+      }
+    },
+    "localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "requires": {
+        "lie": "3.1.1"
       }
     },
     "locate-path": {
@@ -28365,6 +28477,11 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -28975,21 +29092,6 @@
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
     },
-    "p-all": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-all/-/p-all-5.0.0.tgz",
-      "integrity": "sha512-pofqu/1FhCVa+78xNAptCGc9V45exFz2pvBRyIvgXkNM0Rh18Py7j8pQuSjA+zpabI46v9hRjNWmL9EAFcEbpw==",
-      "requires": {
-        "p-map": "^6.0.0"
-      },
-      "dependencies": {
-        "p-map": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
-          "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw=="
-        }
-      }
-    },
     "p-limit": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
@@ -29517,12 +29619,12 @@
       }
     },
     "react-dropzone": {
-      "version": "14.2.3",
-      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.2.3.tgz",
-      "integrity": "sha512-O3om8I+PkFKbxCukfIR3QAGftYXDZfOE2N1mr/7qebQJHs7U+/RSL/9xomJNpRg9kM5h9soQSdf0Gc7OHF5Fug==",
+      "version": "14.3.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
       "requires": {
-        "attr-accept": "^2.2.2",
-        "file-selector": "^0.6.0",
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
         "prop-types": "^15.8.1"
       },
       "dependencies": {
@@ -29920,9 +30022,9 @@
       "dev": true
     },
     "sanitize-html": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
-      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.16.0.tgz",
+      "integrity": "sha512-0s4caLuHHaZFVxFTG74oW91+j6vW7gKbGD6CD2+miP73CE6z6YtOBN0ArtLd2UGyi4IC7K47v3ENUbQX4jV3Mg==",
       "requires": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -29951,9 +30053,9 @@
           }
         },
         "domutils": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-          "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+          "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
           "requires": {
             "dom-serializer": "^2.0.0",
             "domelementtype": "^2.3.0",
@@ -31055,9 +31157,9 @@
       }
     },
     "tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -31343,30 +31445,6 @@
         "lodash": "^4.17.21",
         "minimist": "^1.2.8",
         "rxjs": "^7.8.1"
-      },
-      "dependencies": {
-        "axios": {
-          "version": "1.7.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-          "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
-          "dev": true,
-          "requires": {
-            "follow-redirects": "^1.15.6",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
     "verify": "npm-run-all build lint test"
   },
   "dependencies": {
-    "@patternfly/react-core": "^5.3.4",
-    "@patternfly/react-table": "^5.3.4",
-    "@redhat-cloud-services/frontend-components": "^4.2.14",
-    "@redhat-cloud-services/frontend-components-notifications": "^4.1.0",
-    "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
+    "@patternfly/react-core": "^6.0.0",
+    "@patternfly/react-table": "^6.0.0",
+    "@redhat-cloud-services/frontend-components": "^6.0.2",
+    "@redhat-cloud-services/frontend-components-notifications": "^6.0.0",
+    "@redhat-cloud-services/frontend-components-utilities": "^6.0.2",
     "classnames": "^2.3.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,5 @@
 import React, { Fragment, useEffect } from 'react';
-import { Reducer } from 'redux';
-import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
-import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 import SubscriptionOverview from './Components/SubscriptionOverview';
@@ -12,8 +9,6 @@ const App = () => {
   const { updateDocumentTitle } = useChrome();
 
   useEffect(() => {
-    const registry = getRegistry();
-    registry.register({ notifications: notificationsReducer as Reducer });
     // You can use directly the name of your app
     updateDocumentTitle('Subscriptions Dashboard');
   }, []);

--- a/src/Components/BodyComponent.tsx
+++ b/src/Components/BodyComponent.tsx
@@ -2,14 +2,10 @@ import React from 'react';
 import {
   Card,
   CardBody,
+  Content,
+  ContentVariants,
   Flex,
   FlexItem,
-  Text,
-  TextContent,
-  TextList,
-  TextListItem,
-  TextListVariants,
-  TextVariants,
 } from '@patternfly/react-core';
 import './Overview.scss';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
@@ -24,26 +20,29 @@ const BodyComponent = () => {
       >
         <FlexItem className="body-component--flex-item">
           <CardBody>
-            <TextContent>
-              <Text component={TextVariants.h2}>
+            <Content>
+              <Content component={ContentVariants.h2}>
                 See all your subscriptions
-              </Text>
-            </TextContent>
+              </Content>
+            </Content>
           </CardBody>
           <CardBody className="pf-u-pb-xs pf-u-mb-xs">
-            <TextContent>
-              <Text component={TextVariants.h3}>
+            <Content>
+              <Content component={ContentVariants.h3}>
                 Register your RHEL systems
-              </Text>
-              <Text
+              </Content>
+              <Content
                 className="pf-u-pb-xs pf-u-mb-xs"
-                component={TextVariants.p}
+                component={ContentVariants.p}
               >
                 Get the full value of your RHEL subscriptions, including updates
                 and security patches, through registration.
-              </Text>
-              <TextList component={TextListVariants.ul}>
-                <TextListItem className="body-component--text-list-margins">
+              </Content>
+              <Content component={ContentVariants.ul}>
+                <Content
+                  component="li"
+                  className="body-component--text-list-margins"
+                >
                   For a guided registration experience, try the{' '}
                   <a
                     target="_blank"
@@ -53,8 +52,8 @@ const BodyComponent = () => {
                     {' '}
                     Registration Assistant <ExternalLinkAltIcon />
                   </a>
-                </TextListItem>
-                <TextListItem>
+                </Content>
+                <Content component="li">
                   Review registration alternatives and select the best option
                   for your workflow.{' '}
                   <a
@@ -65,16 +64,16 @@ const BodyComponent = () => {
                     {' '}
                     Learn more <ExternalLinkAltIcon />
                   </a>
-                </TextListItem>
-              </TextList>
-            </TextContent>
+                </Content>
+              </Content>
+            </Content>
           </CardBody>
           <CardBody className="body-component--flex-item body-component--text-list-margins">
-            <TextContent>
-              <Text component={TextVariants.h3}>
+            <Content>
+              <Content component={ContentVariants.h3}>
                 Activate Subscriptions Usage
-              </Text>
-              <Text component={TextVariants.p}>
+              </Content>
+              <Content component={ContentVariants.p}>
                 Gain visibility into the usage of your subscriptions against
                 your total capacity over time. Opt in to Subscriptions Usage
                 today! &nbsp;
@@ -85,13 +84,15 @@ const BodyComponent = () => {
                 >
                   Learn more <ExternalLinkAltIcon />
                 </a>
-              </Text>
-            </TextContent>
+              </Content>
+            </Content>
           </CardBody>
           <CardBody className="body-component--flex-item pf-u-pt-md">
-            <TextContent>
-              <Text component={TextVariants.h3}>Get the right usage data</Text>
-              <Text component={TextVariants.p}>
+            <Content>
+              <Content component={ContentVariants.h3}>
+                Get the right usage data
+              </Content>
+              <Content component={ContentVariants.p}>
                 Account-wide usage reporting relies on multiple data streams to
                 power Subscriptions Usage. Make sure that the right data is
                 flowing for accurate reporting. &nbsp;
@@ -102,8 +103,8 @@ const BodyComponent = () => {
                 >
                   Learn more <ExternalLinkAltIcon />
                 </a>
-              </Text>
-            </TextContent>
+              </Content>
+            </Content>
           </CardBody>
         </FlexItem>
         <FlexItem className="body-component--image">

--- a/src/Components/Dropdown.tsx
+++ b/src/Components/Dropdown.tsx
@@ -6,9 +6,8 @@ import {
   AccordionToggle,
   Card,
   CardBody,
-  Text,
-  TextContent,
-  TextVariants,
+  Content,
+  ContentVariants,
 } from '@patternfly/react-core';
 import './Overview.scss';
 import ExternalLinkAltIcon from '@patternfly/react-icons/dist/js/icons/external-link-alt-icon';
@@ -28,26 +27,22 @@ const Dropdown = () => {
   return (
     <Card>
       <CardBody>
-        <TextContent>
-          <Text component={TextVariants.h2}>Have more questions?</Text>
-        </TextContent>
+        <Content>
+          <Content component={ContentVariants.h2}>Have more questions?</Content>
+        </Content>
       </CardBody>
       <div className="pf-u-pr-lg pf-u-pb-lg">
         <Accordion isBordered>
-          <AccordionItem>
+          <AccordionItem isExpanded={expanded === 'bordered-toggle1'}>
             <AccordionToggle
               onClick={() => {
                 onToggle('bordered-toggle1');
               }}
-              isExpanded={expanded === 'bordered-toggle1'}
               id="bordered-toggle1"
             >
               How can I see all my subscriptions?
             </AccordionToggle>
-            <AccordionContent
-              id="bordered-expand1"
-              isHidden={expanded !== 'bordered-toggle1'}
-            >
+            <AccordionContent id="bordered-expand1">
               <p>
                 View details and status information for each of your
                 subscriptions with{' '}
@@ -59,20 +54,16 @@ const Dropdown = () => {
             </AccordionContent>
           </AccordionItem>
 
-          <AccordionItem>
+          <AccordionItem isExpanded={expanded === 'bordered-toggle2'}>
             <AccordionToggle
               onClick={() => {
                 onToggle('bordered-toggle2');
               }}
-              isExpanded={expanded === 'bordered-toggle2'}
               id="bordered-toggle2"
             >
               What is a manifest?
             </AccordionToggle>
-            <AccordionContent
-              id="bordered-expand2"
-              isHidden={expanded !== 'bordered-toggle2'}
-            >
+            <AccordionContent id="bordered-expand2">
               <p>
                 A manifest is a set of encrypted files that contains
                 subscription information that is used to import your
@@ -101,20 +92,16 @@ const Dropdown = () => {
             </AccordionContent>
           </AccordionItem>
 
-          <AccordionItem>
+          <AccordionItem isExpanded={expanded === 'bordered-toggle3'}>
             <AccordionToggle
               onClick={() => {
                 onToggle('bordered-toggle3');
               }}
-              isExpanded={expanded === 'bordered-toggle3'}
               id="bordered-toggle3"
             >
               How is Subscriptions Usage counting the usage of my subscriptions?
             </AccordionToggle>
-            <AccordionContent
-              id="bordered-expand3"
-              isHidden={expanded !== 'bordered-toggle3'}
-            >
+            <AccordionContent id="bordered-expand3">
               <p>
                 The purchase terms for a subscription determine how usage is
                 counted. These terms include a quantity and unit of measurement.
@@ -132,20 +119,16 @@ const Dropdown = () => {
             </AccordionContent>
           </AccordionItem>
 
-          <AccordionItem>
+          <AccordionItem isExpanded={expanded === 'bordered-toggle4'}>
             <AccordionToggle
               onClick={() => {
                 onToggle('bordered-toggle4');
               }}
-              isExpanded={expanded === 'bordered-toggle4'}
               id="bordered-toggle4"
             >
               How do I prepare to manage my RHEL subscriptions?
             </AccordionToggle>
-            <AccordionContent
-              id="bordered-expand4"
-              isHidden={expanded !== 'bordered-toggle4'}
-            >
+            <AccordionContent id="bordered-expand4">
               <p>
                 Discover the processes and tools that are used to manage your
                 RHEL subscriptions.{' '}

--- a/src/Components/Overview.scss
+++ b/src/Components/Overview.scss
@@ -19,7 +19,7 @@
   object-fit: cover;
   display: block;
   margin: auto;  
-  margin-bottom: var(--pf-v5-global--spacer--md);
+  margin-bottom: var(--pf-t--global--spacer--md);
 }
 
 .subscription-portfolio--icon-color {
@@ -27,8 +27,8 @@
 }
 
 .subscription-portfolio__card-padding {
-  padding-top: var(--pf-v5-global--spacer--md);
-  padding-bottom: var(--pf-v5-global--spacer--md);
+  padding-top: var(--pf-t--global--spacer--md);
+  padding-bottom: var(--pf-t--global--spacer--md);
 }
 
 .body-component--flex-item {
@@ -54,12 +54,12 @@
   flex: 2;
   max-height: "100%";
   max-width: "100%";
-  margin-right: var(--pf-v5-global--spacer--md);
-  margin-bottom: var(--pf-v5-global--spacer--md);
+  margin-right: var(--pf-t--global--spacer--md);
+  margin-bottom: var(--pf-t--global--spacer--md);
   height: "100%";
   width: "100%";
   object-fit: 'cover';
-  margin-left: var(--pf-v5-global--spacer--sm);
+  margin-left: var(--pf-t--global--spacer--sm);
   padding: '0px';
 }
 
@@ -69,19 +69,19 @@
     align-items: start;
   }
   .body-component--flex-item {
-    margin-right: var(--pf-v5-global--spacer--sm);
-    padding-right: var(--pf-v5-global--spacer--sm);
+    margin-right: var(--pf-t--global--spacer--sm);
+    padding-right: var(--pf-t--global--spacer--sm);
   }
   .body-component--image {
     width: 75%;
     height: auto;
-    padding-left: var(--pf-v5-global--spacer--sm);
+    padding-left: var(--pf-t--global--spacer--sm);
   }
   .top-card--right-flex {
     margin: 0 0 0 0 !important;
   }
   .subscription-card-margin {
-    margin-right: var(--pf-v5-global--spacer--md);
+    margin-right: var(--pf-t--global--spacer--md);
   }
 }
 
@@ -91,19 +91,19 @@
     align-items: start;
   }
   .body-component--flex-item {
-    margin-right: var(--pf-v5-global--spacer--xs);
-    padding-right: var(--pf-v5-global--spacer--xs);
+    margin-right: var(--pf-t--global--spacer--xs);
+    padding-right: var(--pf-t--global--spacer--xs);
   }
   .body-component--image {
     width: 85%;
     height: auto;
-    padding-left: var(--pf-v5-global--spacer--sm);
+    padding-left: var(--pf-t--global--spacer--sm);
   }
   .top-card--right-flex {
     margin: 0 0 0 0 !important;
   }
   .subscription-card-margin {
-    margin-right: var(--pf-v5-global--spacer--md);
+    margin-right: var(--pf-t--global--spacer--md);
   }
 }
   
@@ -121,7 +121,7 @@
     flex: 10 !important;
   }
   .top-card__divider {
-    margin: var(--pf-v5-global--spacer--lg) 0px var(--pf-v5-global--spacer--lg) var(--pf-v5-global--spacer--sm) !important; 
+    margin: var(--pf-t--global--spacer--lg) 0px var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--sm) !important; 
   }
 }
 
@@ -139,7 +139,7 @@
       flex: 12 !important;
     }
     .top-card__divider {
-      margin: var(--pf-v5-global--spacer--lg) 0px var(--pf-v5-global--spacer--lg) var(--pf-v5-global--spacer--sm) !important; 
+      margin: var(--pf-t--global--spacer--lg) 0px var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--sm) !important; 
     }
   }
   
@@ -163,7 +163,7 @@
     flex: 2;
   }
   .top-card__divider {
-    margin: var(--pf-v5-global--spacer--lg) 0px var(--pf-v5-global--spacer--lg) 0px !important; 
+    margin: var(--pf-t--global--spacer--lg) 0px var(--pf-t--global--spacer--lg) 0px !important; 
   }
   .top-card--right-flex {
     flex: 13 !important;
@@ -178,7 +178,7 @@
       flex: 2;
     }
     .top-card__divider {
-      margin: var(--pf-v5-global--spacer--lg) 0px var(--pf-v5-global--spacer--lg) 0px !important; 
+      margin: var(--pf-t--global--spacer--lg) 0px var(--pf-t--global--spacer--lg) 0px !important; 
     }
     .top-card--right-flex {
         flex: 14 !important;
@@ -193,7 +193,7 @@
       flex: 2;
     }
     .top-card__divider {
-      margin: var(--pf-v5-global--spacer--lg) 0px var(--pf-v5-global--spacer--lg) 0px !important; 
+      margin: var(--pf-t--global--spacer--lg) 0px var(--pf-t--global--spacer--lg) 0px !important; 
     }
     .top-card--right-flex {
         flex: 16 !important;
@@ -201,13 +201,13 @@
   }
 
 .list-items {
-  padding-left: var(--pf-v5-global--spacer--lg);
+  padding-left: var(--pf-t--global--spacer--lg);
 }
 
 .subscription-portfolio--flex {
   display: flex;
   align-items: start;
-  gap: var(--pf-v5-global--spacer--md);
+  gap: var(--pf-t--global--spacer--md);
 }
 
 .subscription-portfolio__button {
@@ -219,7 +219,7 @@
   text-align: center;
   a {
     span {
-      color: var(--pf-v5-global--link--Color);
+      color: var(--pf-t--temp--dev--tbd /* CODEMODS: original v5 color was:--pf-v5-global--link--Color */);
     }
   }
 }
@@ -231,15 +231,15 @@
 }
 
 .top-card--left-flex {
-  margin: var(--pf-v5-global--spacer--lg) var(--pf-v5-global--spacer--sm) var(--pf-v5-global--spacer--lg) var(--pf-v5-global--spacer--md);
+  margin: var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--sm) var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--md);
   flex: 1;
 }
 
 .top-card--right-flex {
-  margin-right: var(--pf-v5-global--spacer--md);
+  margin-right: var(--pf-t--global--spacer--md);
   flex: 8;
 }
 
 .top-card__divider {
-  margin: var(--pf-v5-global--spacer--lg) 0px var(--pf-v5-global--spacer--lg) var(--pf-v5-global--spacer--md);
+  margin: var(--pf-t--global--spacer--lg) 0px var(--pf-t--global--spacer--lg) var(--pf-t--global--spacer--md);
 }

--- a/src/Components/SubscriptionOverview.tsx
+++ b/src/Components/SubscriptionOverview.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 
 import {
+  Content,
+  ContentVariants,
   Stack,
   StackItem,
-  Text,
-  TextContent,
-  TextVariants,
 } from '@patternfly/react-core';
 
 import { Main } from '@redhat-cloud-services/frontend-components/Main';
@@ -25,15 +24,15 @@ const SubscriptionOverview = () => (
           <BodyComponent />
         </StackItem>
         <StackItem>
-          <TextContent>
-            <Text component={TextVariants.h2}>
+          <Content>
+            <Content component={ContentVariants.h2}>
               Build your subscription portfolio
-            </Text>
-            <Text>
+            </Content>
+            <Content component="p">
               Buy subscriptions for your workloads. We give you data that drives
               your decisions.
-            </Text>
-          </TextContent>
+            </Content>
+          </Content>
         </StackItem>
         <StackItem>
           <SubscriptionPortfolio />

--- a/src/Components/SubscriptionPortfolio.tsx
+++ b/src/Components/SubscriptionPortfolio.tsx
@@ -67,8 +67,12 @@ const SubscriptionPortfolio = () => {
             href="https://www.redhat.com/en/technologies/all-products"
             rel="noreferrer"
           >
-            <Button className="subscription-portfolio__button">
-              <PlusCircleIcon className="subscription-portfolio--image-size subscription-portfolio--icon-color" />
+            <Button
+              icon={
+                <PlusCircleIcon className="subscription-portfolio--image-size subscription-portfolio--icon-color" />
+              }
+              className="subscription-portfolio__button"
+            >
               <span>View all</span>
               <br />
               <span className="pf-u-pl-md pf-u-pr-md">Red Hat Products</span>

--- a/src/Components/TopCard.tsx
+++ b/src/Components/TopCard.tsx
@@ -2,12 +2,11 @@ import React from 'react';
 import {
   Card,
   CardBody,
+  Content,
+  ContentVariants,
   Divider,
   Flex,
   FlexItem,
-  Text,
-  TextContent,
-  TextVariants,
 } from '@patternfly/react-core';
 import './Overview.scss';
 import SubsIcon from '../../static/images/subs.svg';
@@ -25,16 +24,16 @@ const TopCard = () => {
         />
         <FlexItem className="top-card--right-flex">
           <CardBody>
-            <TextContent>
-              <Text component={TextVariants.h1}>
+            <Content>
+              <Content component={ContentVariants.h1}>
                 Welcome to Subscription Services
-              </Text>
-              <Text component={TextVariants.p}>
+              </Content>
+              <Content component={ContentVariants.p}>
                 Empower your buying decisions with data. Subscription Services
                 provide reporting that is designed to make your subscription
                 choices data-driven.
-              </Text>
-            </TextContent>
+              </Content>
+            </Content>
           </CardBody>
         </FlexItem>
       </Flex>

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,16 +1,11 @@
 import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
 import promiseMiddleware from 'redux-promise-middleware';
-import notificationsMiddleware from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
 import ReducerRegistry from '@redhat-cloud-services/frontend-components-utilities/ReducerRegistry';
 import { Middleware, Reducer } from 'redux';
 
 export let registry: ReducerRegistry<Reducer>;
 
 export function init(...middleware: Middleware[]) {
-  registry = getRegistry({}, [
-    promiseMiddleware,
-    notificationsMiddleware({ errorDescriptionKey: ['detail', 'stack'] }),
-    ...middleware,
-  ]);
+  registry = getRegistry({}, [promiseMiddleware, ...middleware]);
   return registry;
 }


### PR DESCRIPTION
This runs the codemods for upgrading to patternfly 6 - specifically the
main codemods as well as the css class mapping one.

It also removes a couple legacy pieces of code that are no longer
supported in the new required version of redhat-cloud-services packages.
