### PR TITLE
Update custom subscription portfolio entry to be the correct size

### DIFF
--- a/src/Components/Overview.scss
+++ b/src/Components/Overview.scss
@@ -224,6 +224,12 @@
   }
 }
 
+.subscription-portfolio__custom_button {
+  flex-direction: column;
+  align-items: center;
+  gap: 0;
+}
+
 .subscription-flex {
   display: 'flex';
   flex-wrap: 'nowrap';

--- a/src/Components/SubscriptionPortfolio.tsx
+++ b/src/Components/SubscriptionPortfolio.tsx
@@ -71,7 +71,7 @@ const SubscriptionPortfolio = () => {
               icon={
                 <PlusCircleIcon className="subscription-portfolio--image-size subscription-portfolio--icon-color" />
               }
-              className="subscription-portfolio__button"
+              className="subscription-portfolio__button subscription-portfolio__custom_button"
             >
               <span>View all</span>
               <br />


### PR DESCRIPTION
One of the subscription portfolio entries is a custom element, and the
custom sizing for it broke. This adds the styling necessary to match the
other three items.