### PR TITLE
Revert "chore: disable Dependabot — updates handled by Konflux (#239)"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,2 +1,0 @@
-version: 2
-updates: []


### PR DESCRIPTION
This reverts commit 5875921e15fa3ea0e704d25659c6693c71cde6a8.

## Summary by Sourcery

Chores:
- Delete the .github/dependabot.yml configuration file.